### PR TITLE
Bugfix for certain (XWayland?) windows crashing wayfire on open.

### DIFF
--- a/src/firedecor-theme.cpp
+++ b/src/firedecor-theme.cpp
@@ -514,7 +514,7 @@ std::string get_from_desktop(std::string path, std::string var) {
 	std::string line;
 	while(std::getline(input_file, line)) {
 		if (auto index = line.find(var); index != std::string::npos) {
-			return (line.substr(index + var.length() + 1));
+			return (line.substr(index + var.length()));
 		}
 	}
 	if (var == "Icon") {


### PR DESCRIPTION
Apologies for sounding rude but is there a reason line.substr is adding 1 on the end during I think is an icon filename search?

Fixes a SIGABRT triggered by opening Steam and/or the Unity Editor while firedecor is running in Wayfire.
This also fixes Wayfire Configuration Manager crashing the entire session as well.

Tested on Arch Linux using a modified PKGBUILD pointed to a local copy of this repo I was using for testing. 